### PR TITLE
Site shapefile and map

### DIFF
--- a/5_data_munge.yml
+++ b/5_data_munge.yml
@@ -3,6 +3,10 @@ target_default: 5_data_munge
 packages:
   - scipiper
   - dplyr
+  - sf
+  - ggplot2
+  - rnaturalearth
+  - rnaturalearthhires
   
 sources:
   - 5_data_munge/src/munge_data_files.R
@@ -84,3 +88,17 @@ targets:
       
   5_data_munge/out/all_sites.rds:
     command: gd_get('5_data_munge/out/all_sites.rds.ind')
+    
+  5_data_munge/out/sites_shp/sites.shp.ind:
+    command: make_sites_shp(
+      out_ind = target_name,
+      all_sites_ind = '5_data_munge/out/all_sites.rds.ind',
+      all_temps_ind = '5_data_munge/out/daily_temperatures.rds.ind')
+  
+  5_data_munge/out/sites_shp/sites.shp:
+    command: gd_get('5_data_munge/out/sites_shp/sites.shp')
+      
+  5_data_munge/out/sites_ndates.png.ind:
+    command: plot_sites_ndates(
+      out_ind = target_name,
+      sites_shp_ind = '5_data_munge/out/sites_shp/sites.shp.ind')

--- a/5_data_munge.yml
+++ b/5_data_munge.yml
@@ -102,3 +102,6 @@ targets:
     command: plot_sites_ndates(
       out_ind = target_name,
       sites_shp_ind = '5_data_munge/out/sites_shp/sites.shp.ind')
+      
+  5_data_munge/out/sites_ndates.png:
+    command: gd_get('5_data_munge/out/sites_ndates.png.ind')


### PR DESCRIPTION
Not ready for merge yet.

Builds and writes a shapefile with site lat/lons and count of dates with observations. However, this shapefile has many sites clearly outside the USA borders.
![image](https://user-images.githubusercontent.com/12039957/74866973-cf969580-5321-11ea-933b-f0e7bb6b46f8.png)

Builds a map (currently subset to just a random sample of 10000 points) showing n_dates. However, this map uses a boring projection, doesn't relocate AK or HI or PR, might be using a slow geometry intersection method(?), and is not pretty. Sam has made prettier ones before.
![sites_ndates](https://user-images.githubusercontent.com/12039957/74866746-5ac35b80-5321-11ea-9a10-e748f43d5df8.png)

Because they're so unfinished, neither of these scipiper targets actually gets pushed to Drive at the moment. Also, because the upstream targets were threatening to repull data, the current code is disconnected from the pipeline for retrieval of those targets. It should be run line-by-line rather than via scipiper for now, and should be edited to connect to the pipeline in the future.